### PR TITLE
Fix jwt.decode usage in test_service_account_key

### DIFF
--- a/tests/test_service_account_auth.py
+++ b/tests/test_service_account_auth.py
@@ -44,7 +44,12 @@ def test_service_account_key(service_account_key):
     request = request_func()
     now = int(time.time())
     headers = jwt.get_unverified_header(request.jwt)
-    parsed = jwt.decode(request.jwt, secret=service_account_key["public_key"], algorithms=['PS256'], verify=False)
+    parsed = jwt.decode(
+        request.jwt,
+        key=service_account_key["public_key"],
+        algorithms=['PS256'],
+        audience="https://iam.api.cloud.yandex.net/iam/v1/tokens",
+    )
     assert headers["typ"] == "JWT"
     assert headers["alg"] == "PS256"
     assert headers["kid"] == service_account_key["id"]


### PR DESCRIPTION
It seems that for current version of pyjwt (2.3.0) public_key should be passed in `key` argument of decode.
Also looks like `verify=True` does nothing and audience check fails so we pass expected value.