### PR TITLE
Use Github Actions as CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,28 @@
+name: Tests
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+            python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: make deps
+
+      - name: Run checks
+        run: make tox

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 __pycache__
 .cache/
 .idea/
-venv/
+venv*
+.tox
+build/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+.DEFAULT_GOAL := help
+.PHONY: deps tox test test-all-versions help
+
+REPO_ROOT:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+deps: ## install deps (library & development)
+	python -m pip install --upgrade pip
+	python -m pip install -r requirements-dev.txt
+
+tox: ## run ALL checks for ALL available python versions
+	python -m tox
+
+test: ## run tests ONLY for current python version
+	python -m pytest
+
+test-all-versions: ## run test for multiple python versions using docker
+	# python 3.10 not provided in image so we skip it
+	docker run --rm -v $(REPO_ROOT):/src fkrull/multi-python tox -c /src -e py36,py37,py38,py39
+
+help: ## Show help message
+	@IFS=$$'\n' ; \
+	help_lines=(`fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##/:/'`); \
+	printf "%s\n\n" "Usage: make [task]"; \
+	printf "%-20s %s\n" "task" "help" ; \
+	printf "%-20s %s\n" "------" "----" ; \
+	for help_line in $${help_lines[@]}; do \
+		IFS=$$':' ; \
+		help_split=($$help_line) ; \
+		help_command=`echo $${help_split[0]} | sed -e 's/^ *//' -e 's/ *$$//'` ; \
+		help_info=`echo $${help_split[2]} | sed -e 's/^ *//' -e 's/ *$$//'` ; \
+		printf '\033[36m'; \
+		printf "%-20s %s" $$help_command ; \
+		printf '\033[0m'; \
+		printf "%s\n" $$help_info; \
+	done

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+-e .
+pytest
+tox
+tox-gh-actions

--- a/tests/metadata_server_mock.py
+++ b/tests/metadata_server_mock.py
@@ -1,6 +1,6 @@
 import json
 import threading
-from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
+from http.server import HTTPServer, BaseHTTPRequestHandler
 
 _MDS_ADDRESS = ("localhost", 50052)
 
@@ -19,7 +19,7 @@ def metadata_server(token):
             self.end_headers()
             self.wfile.write(data)
 
-    srv = ThreadingHTTPServer(_MDS_ADDRESS, MetadataHandler)
+    srv = HTTPServer(_MDS_ADDRESS, MetadataHandler)
     thread = threading.Thread(target=srv.serve_forever)
     thread.daemon = True
     thread.start()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
+
+[tox]
+envlist = py{36,37,38,39,310}
+
+[testenv]
+deps = -rrequirements-dev.txt
+commands = pytest tests


### PR DESCRIPTION
* configure github actions config to run tests against multiple python versions
* configure tox to run multiple checks in one command
* add Makefile for shortcuts
* add command to run tests against multiple python versions locally (in docker)
* fix http mock, so python3.6 can be tested (ThreadingHTTPServer was added in 3.7)