### PR TITLE
Simplify supported modules

### DIFF
--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -1,0 +1,21 @@
+import pytest
+
+from yandexcloud import _sdk
+from yandex.cloud.serverless.functions.v1 import function_service_pb2_grpc
+
+
+@pytest.mark.parametrize(
+    "module_path, expected_endpoint_id",
+    [
+        ("yandex.cloud.ai.stt", "ai-stt"),
+        ("yandex.cloud.serverless.triggers.v1", "serverless-triggers"),
+        ("yandex.cloud.ai.translate.v2", "ai-translate"),
+        ("yandex.cloud.compute.v1.instancegroup", "compute-instancegroup"),
+        (
+            _sdk._get_stub_package(function_service_pb2_grpc.FunctionServiceStub),
+            "serverless-functions"
+        ),
+    ]
+)
+def test_get_default_endpoint_id(module_path, expected_endpoint_id):
+    assert _sdk._get_default_endpoint_id(module_path) == expected_endpoint_id

--- a/yandexcloud/_sdk.py
+++ b/yandexcloud/_sdk.py
@@ -90,7 +90,7 @@ _supported_modules = [
     ('yandex.cloud.ai.stt', 'ai-stt'),
     ('yandex.cloud.ai.translate', 'ai-translate'),
     ('yandex.cloud.ai.vision', 'ai-vision'),
-    ('yandex.cloud.apploadbalancer', 'alb'),
+    ('yandex.cloud.apploadbalancer.v1', 'alb'),
     ('yandex.cloud.billing', 'billing'),
     ('yandex.cloud.cdn', 'cdn'),
     ('yandex.cloud.compute', 'compute'),

--- a/yandexcloud/_sdk.py
+++ b/yandexcloud/_sdk.py
@@ -90,6 +90,7 @@ _supported_modules = [
     ('yandex.cloud.ai.stt', 'ai-stt'),
     ('yandex.cloud.ai.translate', 'ai-translate'),
     ('yandex.cloud.ai.vision', 'ai-vision'),
+    ('yandex.cloud.apploadbalancer', 'alb'),
     ('yandex.cloud.billing', 'billing'),
     ('yandex.cloud.cdn', 'cdn'),
     ('yandex.cloud.compute', 'compute'),


### PR DESCRIPTION
We got several issues regarding absence of some cloud service in manually maintained list of supported endpoints, although there are exist in public api.
Here i tried approach where we try to guess endpoint id based on stub module name if not found in list.
For now we have list of endpoints which are have match with module name
```
ai-stt
ai-translate
ai-vision
billing
cdn
compute
dataproc-manager
dataproc
dns
endpoint
iam
iot-devices
kms
lockbox
logging
operation
serverless-apigateway
serverless-functions
serverless-triggers
vpc
ydb
```
also some new services will be available after this PR
```
datasphere
datatransfer
serverless-containers
```
Default behaviour are left as is: if we cant find endpoint in list in sources or in real endpoints list — we raise error.

So it should be backward compatible and in future we will less often have to put endpoints in hardcoded list.


On other hand it is half-measure because there are still many cloud services with non-guessable endpoint naming, so i guess better approaches: 
1) to **generate** full mapping grpc-service to endpoint_id  (if we have it somewhere already)
2) use endpoint_ids in user api and find stubs for them (still need reverse mapping)