### PR TITLE
Fix deps installation

### DIFF
--- a/.github/workflows/genproto.yml
+++ b/.github/workflows/genproto.yml
@@ -15,6 +15,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+          python-version: "3.10"
+
     - name: Generate code from proto
       run: |
         make submodule

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,14 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+          python-version: "3.10"
+
     - name: Bump version and release to PyPi
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install python-semantic-release
+        make deps
 
         git config --global user.name 'Yandex.Cloud Bot'
         git config --global user.email 'ycloud-bot@yandex.ru'


### PR DESCRIPTION
workflow fails on installing `pip -e .` from requirements
https://github.com/yandex-cloud/python-sdk/runs/5331793782?check_suite_focus=true

Fixed with use of `actions/setup-python@v2` (as in tests workflow) — it works fine.

For consistency and for deduplication made same fix for release workflow