### PR TITLE
Use personal access token to trigger release workflow

### DIFF
--- a/.github/workflows/genproto.yml
+++ b/.github/workflows/genproto.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+          token: ${{ secrets.YANDEX_CLOUD_BOT_TOKEN }}
 
     - name: Set up Python
       uses: actions/setup-python@v2


### PR DESCRIPTION
As it turned out our GENPROTO workflow with commit does not trigger RELEASE workflow.

It [seems](https://stackoverflow.com/a/67551255/871392) that is [intended behaviour](https://docs.github.com/en/enterprise-server@2.22/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) (so we not creating recursive flows)

We need personal access token to push workflow.
https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token