### PR TITLE
Zero exit code when no proto code changes

### DIFF
--- a/.github/workflows/genproto.yml
+++ b/.github/workflows/genproto.yml
@@ -31,5 +31,5 @@ jobs:
         git config --global user.name 'Yandex.Cloud Bot'
         git config --global user.email 'ycloud-bot@yandex.ru'
         git add yandex cloudapi
-        git commit -m 'regenerate proto'
+        git commit -m 'regenerate proto' || echo "No changes in .proto files found"
         git push


### PR DESCRIPTION
Codegen build fails when no changes with
```
nothing to commit, working tree clean
Error: Process completed with exit code 1.
```
https://github.com/yandex-cloud/python-sdk/runs/5342309246?check_suite_focus=true

It looks like something broken, but it is normal, so we fix it to return zero in such case

Example run with fix https://github.com/yandex-cloud/python-sdk/runs/5356921249?check_suite_focus=true