### PR TITLE
Add test/lint in protogenerate workflow

### DIFF
--- a/.github/workflows/genproto.yml
+++ b/.github/workflows/genproto.yml
@@ -27,6 +27,7 @@ jobs:
         make submodule
         make deps
         make proto
+        make tox
         
         git config --global user.name 'Yandex.Cloud Bot'
         git config --global user.email 'ycloud-bot@yandex.ru'

--- a/.pylintrc
+++ b/.pylintrc
@@ -10,6 +10,7 @@ disable=
     C0209, # Formatting a regular string which could be a f-string (consider-using-f-string)
     C0301, # Line too long (126/120) (line-too-long) — checked with flake8 anyway
     C0411, # FIXME with black and remove standard import "from datetime import datetime" should be placed before "import grpc" (wrong-import-order)
+    E0611, # No name 'Empty' in module 'google.protobuf.empty_pb2' (no-name-in-module) — proto code creates attributes in runtime and linter goes crazy
     R0205, # Class 'OperationResult' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
     R0903, # Too few public methods (1/2) (too-few-public-methods)
     R0913, # Too many arguments (6/5) (too-many-arguments)


### PR DESCRIPTION
As far as I understand, the google protobuf library creates some objects and puts them on module level at import time. Pylint is not happy with it, but those names are importable in fact.

1) I added linter exception for this kind of problem, it seems that we will have more false positives here than useful alerts.
2) I added tests & linting in protogeneration workflow, so we have a green master and won't have a situation, when honest developer tries to make small change and have to deal with broken builds like it happened here https://github.com/yandex-cloud/python-sdk/pull/51

PS I do not know why python 3.6 not fails, i guess pylint may cut it from the newest versions of the library and check not happening in old version of pylint. Haven't chance to debug this behavior, can't install python3.6 on my macbook (only pythons 3.7+).