### PR TITLE
Freeze protobuf lib in dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     install_requires=[
         "cryptography>=2.8",
         "grpcio>=1.38.1",
+        "protobuf<3.21",
         "googleapis-common-protos>=1.53.0",
         "pyjwt>=1.7.1",
         "requests>=2.22.0",


### PR DESCRIPTION
We have frozen `grpcio-tools` dependency in requirements-dev and unfrozen dependency `googleapis-common-protos`. The result is that the resulting stubs are not compatible with the runtime protobuf library version.
So we freeze the runtime protobuf version while figuring out a better solution.