### PR TITLE
Drop python 3.6 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - name: Checkout sources

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,12 @@
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
 
 [tox]
-envlist = py{36,37,38,39,310}
+envlist = py{37,38,39,310}
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
Python 3.6 support reached end of life phase at 2021-12-23 and is not available in latest ubuntu for github actions
https://peps.python.org/pep-0494/#lifespan