### PR TITLE
Update _sdk.py for storage-api

### DIFF
--- a/yandexcloud/_sdk.py
+++ b/yandexcloud/_sdk.py
@@ -131,7 +131,7 @@ _supported_modules = [
     ("yandex.cloud.serverless.containers", "serverless-containers"),
     ("yandex.cloud.serverless.functions", "serverless-functions"),
     ("yandex.cloud.serverless.triggers", "serverless-triggers"),
-    ("yandex.cloud.storage", "storage"),
+    ("yandex.cloud.storage", "storage-api"),
     ("yandex.cloud.vpc", "vpc"),
     ("yandex.cloud.ydb", "ydb"),
 ]


### PR DESCRIPTION
The proper lookup key for the endpoint of storage API is "storage-api", so I'm fixing that