### PR TITLE
use version_variables for semantic_release v8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.semantic_release]
-version_variable = "setup.py:__version__"
+version_variables = ["setup.py:__version__"]
 # https://python-semantic-release.readthedocs.io/en/latest/configuration.html#major-on-zero
 major_on_zero = false
 commit_parser="changelog.parse_commit"


### PR DESCRIPTION
The semantic_release package has released a new version. There is a new way to pass a file with current version: https://python-semantic-release.readthedocs.io/en/latest/migrating_from_v7.html#version-variable