### PR TITLE
Upgrade workflows actions versions

### DIFF
--- a/.github/workflows/genproto.yml
+++ b/.github/workflows/genproto.yml
@@ -13,12 +13,12 @@ jobs:
     concurrency: genproto
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
           token: ${{ secrets.YANDEX_CLOUD_BOT_TOKEN }}
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
           python-version: "3.10"
 

--- a/.github/workflows/genproto.yml
+++ b/.github/workflows/genproto.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-          python-version: "3.10"
+          python-version: "3.12"
 
     - name: Generate code from proto
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-          python-version: "3.10"
+          python-version: "3.12"
 
     - name: Bump version and release to PyPi
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,12 @@ jobs:
     concurrency: release
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
           python-version: "3.10"
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
             python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
* use python 3.12 in release and genproto workflows
* upgraded actions `checkout` and `setup-python`